### PR TITLE
Replicas should be 1

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -53,8 +53,8 @@ configlib.configFile(process.argv[2], function (conf, oldConfig) {
   var ring = new hashring(
     node_ring, 'md5', {
       'max cache size': config.cacheSize || 10000,
-      //We don't want duplicate keys sent so replicas set to 0
-      'replicas': 0
+      //We don't want duplicate keys sent so replicas set to 1
+      'replicas': 1
     });
 
   // Do an initial rount of health checks prior to starting up the server


### PR DESCRIPTION
This really does mean 1 replica  (which is only 1 server) not 2,  setting it to zero means NO to proxy servers (which is nonsense) .. at least according to the hashring code.
